### PR TITLE
Switch to relative imports for downstream dependency compatibility

### DIFF
--- a/src/CreateOfferer.sol
+++ b/src/CreateOfferer.sol
@@ -15,7 +15,7 @@ import {
     CreateOffererErrors as Errors,
     CreateOffererHelpers as Helpers,
     CreateOffererModifiers as Modifiers
-} from "src/libraries/CreateOffererLib.sol";
+} from "./libraries/CreateOffererLib.sol";
 
 import {ERC1155Holder} from "openzeppelin/token/ERC1155/utils/ERC1155Holder.sol";
 

--- a/src/DelegateToken.sol
+++ b/src/DelegateToken.sol
@@ -2,15 +2,15 @@
 pragma solidity ^0.8.21;
 
 import {IDelegateToken, IERC721Metadata, IERC721Receiver, IERC1155Receiver} from "./interfaces/IDelegateToken.sol";
-import {MarketMetadata} from "src/MarketMetadata.sol";
-import {PrincipalToken} from "src/PrincipalToken.sol";
+import {MarketMetadata} from "./MarketMetadata.sol";
+import {PrincipalToken} from "./PrincipalToken.sol";
 
 import {ReentrancyGuard} from "openzeppelin/security/ReentrancyGuard.sol";
 
-import {IDelegateRegistry, DelegateTokenErrors as Errors, DelegateTokenStructs as Structs, DelegateTokenHelpers as Helpers} from "src/libraries/DelegateTokenLib.sol";
-import {DelegateTokenStorageHelpers as StorageHelpers} from "src/libraries/DelegateTokenStorageHelpers.sol";
-import {DelegateTokenRegistryHelpers as RegistryHelpers, RegistryHashes} from "src/libraries/DelegateTokenRegistryHelpers.sol";
-import {DelegateTokenTransferHelpers as TransferHelpers, SafeERC20, IERC721, IERC20, IERC1155} from "src/libraries/DelegateTokenTransferHelpers.sol";
+import {IDelegateRegistry, DelegateTokenErrors as Errors, DelegateTokenStructs as Structs, DelegateTokenHelpers as Helpers} from "./libraries/DelegateTokenLib.sol";
+import {DelegateTokenStorageHelpers as StorageHelpers} from "./libraries/DelegateTokenStorageHelpers.sol";
+import {DelegateTokenRegistryHelpers as RegistryHelpers, RegistryHashes} from "./libraries/DelegateTokenRegistryHelpers.sol";
+import {DelegateTokenTransferHelpers as TransferHelpers, SafeERC20, IERC721, IERC20, IERC1155} from "./libraries/DelegateTokenTransferHelpers.sol";
 
 contract DelegateToken is ReentrancyGuard, IDelegateToken {
     /*//////////////////////////////////////////////////////////////

--- a/src/MarketMetadata.sol
+++ b/src/MarketMetadata.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.21;
 
-import {IDelegateToken} from "src/interfaces/IDelegateToken.sol";
-import {DelegateTokenStructs} from "src/libraries/DelegateTokenLib.sol";
+import {IDelegateToken} from "./interfaces/IDelegateToken.sol";
+import {DelegateTokenStructs} from "./libraries/DelegateTokenLib.sol";
 
 import {Ownable2Step} from "openzeppelin/access/Ownable2Step.sol";
 import {ERC2981} from "openzeppelin/token/common/ERC2981.sol";

--- a/src/PrincipalToken.sol
+++ b/src/PrincipalToken.sol
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.21;
 
-import {IDelegateToken} from "src/interfaces/IDelegateToken.sol";
+import {IDelegateToken} from "./interfaces/IDelegateToken.sol";
 
 import {ERC721} from "openzeppelin-contracts/contracts/token/ERC721/ERC721.sol";
 import {IERC2981} from "openzeppelin-contracts/contracts/interfaces/IERC2981.sol";
-import {MarketMetadata} from "src/MarketMetadata.sol";
+import {MarketMetadata} from "./MarketMetadata.sol";
 
 /// @notice A simple NFT that doesn't store any user data, being tightly linked to the stateful Delegate Token.
 /// @notice The holder of the PT is eligible to reclaim the escrowed NFT when the DT expires or is burned.

--- a/src/interfaces/IDelegateFlashloan.sol
+++ b/src/interfaces/IDelegateFlashloan.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.4;
 
-import {DelegateTokenStructs as Structs} from "src/libraries/DelegateTokenLib.sol";
+import {DelegateTokenStructs as Structs} from "../libraries/DelegateTokenLib.sol";
 
 interface IDelegateFlashloan {
     error InvalidFlashloan();

--- a/src/interfaces/IDelegateToken.sol
+++ b/src/interfaces/IDelegateToken.sol
@@ -6,7 +6,7 @@ import {IERC721Receiver} from "openzeppelin/token/ERC721/IERC721Receiver.sol";
 import {IERC1155Receiver} from "openzeppelin/token/ERC1155/IERC1155Receiver.sol";
 import {IERC2981} from "openzeppelin/interfaces/IERC2981.sol";
 
-import {DelegateTokenStructs as Structs} from "src/libraries/DelegateTokenLib.sol";
+import {DelegateTokenStructs as Structs} from "../libraries/DelegateTokenLib.sol";
 
 interface IDelegateToken is IERC721Metadata, IERC721Receiver, IERC1155Receiver, IERC2981 {
     /*//////////////////////////////////////////////////////////////

--- a/src/libraries/CreateOffererLib.sol
+++ b/src/libraries/CreateOffererLib.sol
@@ -3,9 +3,9 @@ pragma solidity ^0.8.4;
 
 import {SpentItem, ReceivedItem} from "seaport/contracts/interfaces/ContractOffererInterface.sol";
 import {ItemType} from "seaport/contracts/lib/ConsiderationEnums.sol";
-import {IDelegateToken, Structs as IDelegateTokenStructs} from "src/interfaces/IDelegateToken.sol";
+import {IDelegateToken, Structs as IDelegateTokenStructs} from "../interfaces/IDelegateToken.sol";
 import {RegistryHashes} from "delegate-registry/src/libraries/RegistryHashes.sol";
-import {IDelegateRegistry, DelegateTokenHelpers} from "src/libraries/DelegateTokenLib.sol";
+import {IDelegateRegistry, DelegateTokenHelpers} from "./DelegateTokenLib.sol";
 
 library CreateOffererErrors {
     error InvalidTokenType(IDelegateRegistry.DelegationType invalidType);

--- a/src/libraries/DelegateTokenLib.sol
+++ b/src/libraries/DelegateTokenLib.sol
@@ -2,7 +2,7 @@
 pragma solidity ^0.8.4;
 
 import {IDelegateRegistry} from "delegate-registry/src/IDelegateRegistry.sol";
-import {IDelegateFlashloan} from "src/interfaces/IDelegateFlashloan.sol";
+import {IDelegateFlashloan} from "../interfaces/IDelegateFlashloan.sol";
 import {IERC721Receiver} from "openzeppelin/token/ERC721/IERC721Receiver.sol";
 
 library DelegateTokenStructs {

--- a/src/libraries/DelegateTokenRegistryHelpers.sol
+++ b/src/libraries/DelegateTokenRegistryHelpers.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.4;
 
 import {RegistryStorage} from "delegate-registry/src/libraries/RegistryStorage.sol";
 import {RegistryHashes} from "delegate-registry/src/libraries/RegistryHashes.sol";
-import {IDelegateRegistry, DelegateTokenErrors as Errors, DelegateTokenStructs as Structs} from "src/libraries/DelegateTokenLib.sol";
+import {IDelegateRegistry, DelegateTokenErrors as Errors, DelegateTokenStructs as Structs} from "./DelegateTokenLib.sol";
 
 library DelegateTokenRegistryHelpers {
     /**

--- a/src/libraries/DelegateTokenStorageHelpers.sol
+++ b/src/libraries/DelegateTokenStorageHelpers.sol
@@ -1,8 +1,8 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.4;
 
-import {DelegateTokenErrors as Errors, DelegateTokenStructs as Structs} from "src/libraries/DelegateTokenLib.sol";
-import {PrincipalToken} from "src/PrincipalToken.sol";
+import {DelegateTokenErrors as Errors, DelegateTokenStructs as Structs} from "./DelegateTokenLib.sol";
+import {PrincipalToken} from "../PrincipalToken.sol";
 
 library DelegateTokenStorageHelpers {
     /// @dev Use this to syntactically store the max of the expiry

--- a/src/libraries/DelegateTokenTransferHelpers.sol
+++ b/src/libraries/DelegateTokenTransferHelpers.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: CC0-1.0
 pragma solidity ^0.8.4;
 
-import {IDelegateRegistry, DelegateTokenErrors as Errors, DelegateTokenStructs as Structs} from "src/libraries/DelegateTokenLib.sol";
+import {IDelegateRegistry, DelegateTokenErrors as Errors, DelegateTokenStructs as Structs} from "./DelegateTokenLib.sol";
 import {IERC1155} from "openzeppelin/token/ERC1155/IERC1155.sol";
 import {IERC721} from "openzeppelin/token/ERC721/IERC721.sol";
 import {IERC20} from "openzeppelin/token/ERC20/IERC20.sol";


### PR DESCRIPTION
Since solc is insane, absolute imports work fine when developing a project, but break when that project is imported as a dependency, leading to bizarre and confusing compilation errors.

I believe relative imports will fix this name "collision" @zodomo ran into
![telegram-cloud-document-1-4985825009038525436](https://github.com/delegatexyz/delegate-market/assets/6371847/ced852e7-3f34-4474-b8b2-5614980e0542)

Source: trust me bro
